### PR TITLE
Requestable list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Anime episode discussion post bot for use with a [Lemmy](https://join-lemmy.org/
   - [user_thread](https://github.com/wjs018/rikka?tab=readme-ov-file#the-user_thread-module)
   - [listen](https://github.com/wjs018/rikka?tab=readme-ov-file#the-listen-module)
   - [summary](https://github.com/wjs018/rikka?tab=readme-ov-file#the-summary-module)
+  - [requestable](https://github.com/wjs018/rikka?tab=readme-ov-file#the-requestable-module)
 - [First Time Setup and Usage](https://github.com/wjs018/rikka?tab=readme-ov-file#first-time-setup-and-usage)
 - [Automating Rikka](https://github.com/wjs018/rikka?tab=readme-ov-file#automating-rikka)
 
@@ -35,6 +36,7 @@ Anime episode discussion post bot for use with a [Lemmy](https://join-lemmy.org/
 - `requests`
 - `pyyaml`
 - `python-dateutil`
+- `jinja2`
 - `pythorhead` >= 0.20.0
 
 ## Design notes
@@ -343,6 +345,26 @@ Alternatively, to simply update the most recently created summary post, run with
 ```bash
 python src/rikka.py -m summary update
 ```
+
+### The requestable Module
+
+This module does not directly post anything to lemmy or modify the database in any way. Instead, it is used to create a formatted markdown document summarizing the status of several groups of shows in the rikka's database. There are three groups of shows that are summarized in the document:
+
+1. Currently Enabled Shows - any show marked enabled in the database is listed in this table with a link to the most recent discussion post (if it exists)
+2. Requestable Shows - these are shows that have had recently aired episodes but they were ignored for whatever reason (lack of engagement or marked as disabled). This is the list of shows that are eligible for threads to be created with the `listen` module. The most recently aired episode is listed as well.
+3. Upcoming Shows - these shows are not marked as enabled and also don't have a recently aired episode. The table also includes the premiere time (in UTC) for the next airing episode
+
+The purpose of this module is to make a nicely formatted markdown document that can then be used to keep something like a wiki up to date automatically. The scripting to handle moving the saved file into the proper destination and do any wiki management is out of scope for rikka. Personally, I use bash scripting to automate wiki updates from this module by taking the output file from this module and appending it onto a file in the wiki directory that is managed with git.
+
+To configure this module, there are two parameters to set in the `[requestable]` section of the config file. The first is `template_file` which points to the jinja template file to use. I have provided a template file in this repository named `requestable_template.md`. The second parameter to set is the `output_filename` to use for the new markdown file to be created with the formatted output. By default, this will be `requestable.md`.
+
+To run this module, there are no cli parameters as it is configured via the config file. So, it is simply:
+
+```bash
+python src/rikka.py -m requestable
+```
+
+This will use the template file to create the output file that reflects the current state of rikka's database. This output file can then be used in whatever way you want via additional, external scripting.
 
 ## First Time Setup and Usage
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -164,6 +164,10 @@ summary_body =
     *This post was created by a bot. Message the mod team for feedback and comments.*
     *The original source code can be found on [GitHub](https://github.com/wjs018/rikka).*
 
+[requestable]
+template_file = requestable_template.md
+output_filename = requestable.md
+
 [megathread]
 # Maximum number of episodes to include in one megathread before creating a new one
 megathread_episodes = 12

--- a/requestable_template.md
+++ b/requestable_template.md
@@ -1,0 +1,34 @@
+## Already Enabled Shows
+
+These shows are being tracked and are currently enabled in rikka's database. This means that when a new episode airs a discussion thread will be created unless the previous episode's discussion thread (if it exists) fails to meet the engagement criteria to continue posts for this show.
+
+| Show Name | English Show Name | AniList Link | Most Recent Discussion |
+| :-------- | :---------------- | :----------- | :--------------------: |
+{% for show in context.enabled %}
+| {{show[0]}} | {{show[1]}} | {{show[2]}} | {{show[3]}} |
+{% endfor %}
+{% raw %}{.dense}{% endraw %}
+
+
+## Requestable Shows
+
+These shows have had episodes air already, but no thread was created because the show was disabled. It is possible to request a discussion thread be created for these shows by pm'ing the bot. Please see the [Bot User Guide](https://wiki.lemmyanime.com/en/rikka) for detailed instructions on how to request a thread via pm.
+
+| Show Name | English Show Name | AniList Link | Most Recently Episode Number  |
+| :-------- | :---------------- | :----------- | :--------------------------: |
+{% for show in context.requestable %}
+| {{show[0]}} | {{show[1]}} | {{show[2]}} | {{show[3]}} |
+{% endfor %}
+{% raw %}{.dense}{% endraw %}
+
+
+## Upcoming Shows
+
+These shows have episodes scheduled to air in the near future but are not already enabled. This means that no discussion thread will be created when it does air. Once an episode has aired, it will move from this table up into the **Requestable Shows** table. At that point, you are able to request the show from rikka via pm ([instructions](https://wiki.lemmyanime.com/en/rikka)). If you want to enable this show in the database prior to this, you can try pm'ing rikka's maintainer [wjs018@ani.social](https://ani.social/u/wjs018) and he can enable it manually in a (relatively) timely manner.
+
+| Show Name | English Show Name | AniList Link | Airing Time (UTC) |
+| :-------- | :---------------- | :----------- | :---------------: |
+{% for show in context.upcoming %}
+| {{show[0]}} | {{show[1]}} | {{show[2]}} | {{show[3]}} |
+{% endfor %}
+{% raw %}{.dense}{% endraw %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ unidecode
 requests
 pyyaml
 python-dateutil
+jinja2
 pythorhead>=0.20.0

--- a/src/config.py
+++ b/src/config.py
@@ -72,6 +72,10 @@ class Config:
         self.summary_body = None
         self.alphabetize = None
 
+        # requestable section
+        self.template_file = None
+        self.output_filename = None
+
         # megathread section
         self.megathread_episodes = None
         self.megathread_title = None
@@ -163,6 +167,11 @@ def from_file(file_path):
         config.summary_title = sec.get("summary_title", None)
         config.summary_body = sec.get("summary_body", None)
         config.alphabetize = sec.getboolean("alphabetize", False)
+
+    if "requestable" in parsed:
+        sec = parsed["requestable"]
+        config.template_file = sec.get("template_file", None)
+        config.output_filename = sec.get("output_filename", "requestable.md")
 
     if "megathread" in parsed:
         sec = parsed["megathread"]

--- a/src/module_requestable.py
+++ b/src/module_requestable.py
@@ -1,0 +1,195 @@
+"""Module to create a formatted page that lists the status of shows"""
+
+import datetime
+
+from jinja2 import Template
+
+from logging import debug, info
+
+
+def main(config, db, *args, **kwargs):
+    """Main function for the module"""
+
+    # Dict object to hold everything for jinja
+    context = {}
+
+    # First, compile list of currently enabled shows
+    result = _get_enabled_shows(db)
+    context["enabled"] = result[0]
+    processed_ids = result[1]
+
+    # Second, compile list of shows with at least one entry in IgnoredEpisodes table
+    # Make sure they are not already in enabled shows list
+    result = _get_requestable_shows(db, processed_ids)
+    context["requestable"] = result[0]
+    processed_ids = result[1]
+
+    # Third, compile list of shows with at least one entry in UpcomingEpisodes table
+    # Make sure they are not already in the previous two lists
+    result = _get_upcoming_shows(db, processed_ids)
+    context["upcoming"] = result[0]
+    processed_ids = result[1]
+
+    # Finally, put it all in one dict and then process the jinja template
+    with open(config.template_file, "r") as file:
+        template = Template(file.read(), trim_blocks=True)
+    rendered = template.render(context=context)
+
+    with open(config.output_filename, "w", encoding="utf8") as file:
+        file.write(rendered)
+
+
+def _get_enabled_shows(db):
+    """
+    Return list of all enabled shows in the database and separate list of all show ids.
+
+    Returned object is of form [list of shows, list of ids]
+
+    Format for each item in list of shows:
+        result[0]       Show name
+        result[1]       Show name in English
+        result[2]       AniList link
+        result[3]       Link to most recent discussion (if exists)
+    """
+
+    list_of_shows = []
+    list_of_ids = []
+
+    info("Fetching enabled shows from the database")
+    db_shows = db.get_shows()
+    info("Found {} enabled shows".format(len(db_shows)))
+
+    for show in db_shows:
+        debug("Handling show with id {}".format(show.id))
+        list_of_ids.append(show.id)
+
+        # Gather and construct the info we need for the show
+        list_for_show = []
+        list_for_show.append(show.name)
+
+        # If no separate English name exists, just reuse the romaji
+        if not show.name_en:
+            list_for_show.append(show.name)
+        else:
+            list_for_show.append(show.name_en)
+
+        list_for_show.append("https://anilist.co/anime/" + str(show.id))
+
+        # Fetch the most recent episode if it exists
+        debug("Fetching most recent episode for show with id {}".format(show.id))
+        latest = db.get_latest_episode(show)
+
+        if latest:
+            list_for_show.append("[Link]({})".format(latest.link))
+        else:
+            list_for_show.append("")
+
+        list_of_shows.append(list_for_show)
+
+    list_of_shows.sort(key=lambda x: x[1])
+
+    return [list_of_shows, list_of_ids]
+
+
+def _get_requestable_shows(db, processed_ids):
+    """
+    Return list of all requestable shows not already enabled and list of newly added ids
+
+    Returned object is of form [list of shows, list of ids]
+
+    Format for each item in list of shows:
+        result[0]       Show name
+        result[1]       Show name in English
+        result[2]       AniList link
+        result[3]       Most recently aired episode number
+    """
+
+    list_of_shows = []
+
+    info("Getting list of ignored shows from the database")
+    ignored_shows = db.get_ignored_shows()
+    info("Found {} ignored shows".format(len(ignored_shows)))
+
+    for show in ignored_shows:
+        if show.id in processed_ids:
+            continue
+
+        debug("Handling show with id {}".format(show.id))
+        processed_ids.append(show.id)
+
+        # Gather and construct the info we need for the show
+        list_for_show = []
+        list_for_show.append(show.name)
+
+        # If no separate English name exists, just reuse the romaji
+        if not show.name_en:
+            list_for_show.append(show.name)
+        else:
+            list_for_show.append(show.name_en)
+
+        list_for_show.append("https://anilist.co/anime/" + str(show.id))
+
+        debug(
+            "Fetching most recently ignored episode for show with id {}".format(show.id)
+        )
+        recent = db.get_most_recent_ignored(show.id)
+        list_for_show.append("Episode " + str(recent.number))
+
+        list_of_shows.append(list_for_show)
+
+    list_of_shows.sort(key=lambda x: x[1])
+
+    return [list_of_shows, processed_ids]
+
+
+def _get_upcoming_shows(db, processed_ids):
+    """
+    Return list of all upcoming shows not already enabled and list of newly added ids
+
+    Returned object is of form [list of shows, list of ids]
+
+    Format for each item in list of shows:
+        result[0]       Show name
+        result[1]       Show name in English
+        result[2]       AniList link
+        result[3]       Airing time for first episode in GMT
+    """
+
+    list_of_shows = []
+
+    info("Getting list of upcoming shows from the database")
+    upcoming_shows = db.get_upcoming_shows()
+    info("Found {} upcoming shows".format(len(upcoming_shows)))
+
+    for show in upcoming_shows:
+        if show.id in processed_ids:
+            continue
+
+        debug("Handling show with id {}".format(show.id))
+        processed_ids.append(show.id)
+
+        # Gather and construct the info we need for the show
+        list_for_show = []
+        list_for_show.append(show.name)
+
+        # If no separate English name exists, just reuse the romaji
+        if not show.name_en:
+            list_for_show.append(show.name)
+        else:
+            list_for_show.append(show.name_en)
+
+        list_for_show.append("https://anilist.co/anime/" + str(show.id))
+
+        # Get the airing time of the next episode in GMT
+        debug("Getting next episode for show with id {}".format(show.id))
+        next_ep = db.get_next_episode(show.id)
+        time_str = datetime.datetime.fromtimestamp(
+            next_ep.airing_time, tz=datetime.timezone.utc
+        ).strftime("%B %d at %H:%M")
+        list_for_show.append(time_str)
+
+        list_of_shows.append(list_for_show)
+
+    list_of_shows.sort(key=lambda x: x[1])
+
+    return [list_of_shows, processed_ids]

--- a/src/rikka.py
+++ b/src/rikka.py
@@ -16,7 +16,7 @@ from data import database
 # Metadata
 name = "Rikka"
 description = "episode discussion bot"
-version = "0.7.1"
+version = "0.7.4"
 
 
 def main(config, args, extra_args):
@@ -106,6 +106,15 @@ def main(config, args, extra_args):
 
             m.main(config, db, *extra_args)
 
+        elif config.module == "requestable":
+            debug(
+                "Outputting a formatted list of enabled,"
+                " requestable, and upcoming shows"
+            )
+            import module_requestable as m  # pylint: disable=import-outside-toplevel
+
+            m.main(config, db, *extra_args)
+
     except:
         exception("Unknown exception or error")
         db._db.rollback()
@@ -141,6 +150,7 @@ if __name__ == "__main__":
             "user_thread",
             "listen",
             "summary",
+            "requestable",
         ],
         default=["episode"],
         help="runs the specified module",


### PR DESCRIPTION
This adds the `requestable` module in order to simplify and automate some wiki maintenance using external tools. For a more detailed discussion of the module, please see the updated README.

There are no database updates needed for this release.

There is a new section of the config file that needs to be added to make use of this module. The example file includes the new `[requestable]` section. To use the default template file from this repo, this section should look like this:

```ini
[requestable]
template_file = requestable_template.md
output_filename = requestable.md
```

Finally, to make use of this module, there is an additional python dependency. Specifically, the jinja2 module must be installed. The `requirements.txt` and README has been updated to reflect this.