### PR TITLE
Add wiki module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Anime episode discussion post bot for use with a [Lemmy](https://join-lemmy.org/
   - [listen](https://github.com/wjs018/rikka?tab=readme-ov-file#the-listen-module)
   - [summary](https://github.com/wjs018/rikka?tab=readme-ov-file#the-summary-module)
   - [requestable](https://github.com/wjs018/rikka?tab=readme-ov-file#the-requestable-module)
+  - [wiki](https://github.com/wjs018/rikka?tab=readme-ov-file#the-wiki-module)
 - [First Time Setup and Usage](https://github.com/wjs018/rikka?tab=readme-ov-file#first-time-setup-and-usage)
 - [Automating Rikka](https://github.com/wjs018/rikka?tab=readme-ov-file#automating-rikka)
 
@@ -365,6 +366,40 @@ python src/rikka.py -m requestable
 ```
 
 This will use the template file to create the output file that reflects the current state of rikka's database. This output file can then be used in whatever way you want via additional, external scripting.
+
+### The wiki Module
+
+This module is designed to create a formatted markdown page for each season that has shows that rikka has created discussion threads for. Similar to the `requestable` module, these files are intended to then be hooked into other scripts to do with what you want. An example of how they can be used (and how I use them) is to create these formatted markdown files whenever a new episode thread is created, then via bash scripting, copying them over to a wiki.js git directory, committing the changes and updating the wiki automatically.
+
+The template file used for this module can be specified in the config file as `wiki_template` in the `[wiki]` section. The subfolder to output the files to (organized by year) can be specified with the `wiki_folder` parameter. Additionally, the show section headings can be specified in this section (see the example config file for reference). To generate all the output files, you can simply run the module with no arguments:
+
+```bash
+python src/rikka.py -m wiki
+```
+
+There are some additional ways to use this module to make managing things easier. To mark that a show should not be included in the output, you can use arguments to specify the AniList id:
+
+```bash
+python src/rikka.py -m wiki disable 457
+```
+
+Alternatively, to re-enable the show for inclusion in the output files, use the `enable` argument with the AniList id:
+
+```bash
+python src/rikka.py -m wiki enable 457
+```
+
+Finally, it is possible to perform bulk actions on all the shows within a given season (as specified by AniList). To do so, instead of specifying an AniList id, simply provide the season name and year:
+
+```bash
+python src/rikka.py -m wiki disable Winter 2024
+```
+
+Or, to re-enable the shows in the season:
+
+```bash
+python src/rikka.py -m wiki enable Winter 2024
+```
 
 ## First Time Setup and Usage
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -168,6 +168,12 @@ summary_body =
 template_file = requestable_template.md
 output_filename = requestable.md
 
+[wiki]
+wiki_template = season_template.md
+wiki_folder = wiki
+wiki_show_heading = {show_name}
+wiki_show_heading_with_en = {show_name} • {show_name_en}
+
 [megathread]
 # Maximum number of episodes to include in one megathread before creating a new one
 megathread_episodes = 12

--- a/season_template.md
+++ b/season_template.md
@@ -1,0 +1,10 @@
+Below, you can find an index of all the discussion threads for shows from the {{context.season}} {{context.year}} anime season. Not every episode of every show may have a discussion thread. To more easily find the show you are looking for, use the navigation menu for this page or use Ctrl+F.
+
+{% for show in context.shows %}
+## {{show[0]}}
+
+{{show[1]}}
+{% raw %}{.dense}{% endraw %}
+
+
+{% endfor %}

--- a/src/config.py
+++ b/src/config.py
@@ -76,6 +76,12 @@ class Config:
         self.template_file = None
         self.output_filename = None
 
+        # wiki section
+        self.wiki_template = None
+        self.wiki_folder = None
+        self.wiki_show_heading = None
+        self.wiki_show_heading_with_en = None
+
         # megathread section
         self.megathread_episodes = None
         self.megathread_title = None
@@ -172,6 +178,13 @@ def from_file(file_path):
         sec = parsed["requestable"]
         config.template_file = sec.get("template_file", None)
         config.output_filename = sec.get("output_filename", "requestable.md")
+
+    if "wiki" in parsed:
+        sec = parsed["wiki"]
+        config.wiki_template = sec.get("wiki_template", "season_template.md")
+        config.wiki_folder = sec.get("wiki_folder", "wiki")
+        config.wiki_show_heading = sec.get("wiki_show_heading", None)
+        config.wiki_show_heading_with_en = sec.get("wiki_show_heading_with_en", None)
 
     if "megathread" in parsed:
         sec = parsed["megathread"]

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -146,6 +146,8 @@ class UnprocessedShow:
         is_airing,
         external_links,
         images,
+        season,
+        year,
     ):
         self.media_id = media_id
         self.id_mal = id_mal
@@ -158,6 +160,8 @@ class UnprocessedShow:
         self.is_airing = is_airing
         self.external_links = external_links
         self.images = images
+        self.season = season
+        self.year = year
 
     def __eq__(self, other):
         return self.media_id == other.media_id

--- a/src/helper_functions.py
+++ b/src/helper_functions.py
@@ -25,6 +25,11 @@ query ($page: Int, $id_in: [Int]) {
       }
       format
       source
+      season
+      seasonYear
+      startDate {
+        year
+      }
       synonyms
       isAdult
       status
@@ -124,6 +129,13 @@ def add_update_shows_by_id(
             )
             db.add_image(image, commit=True)
 
+        debug(
+            "Updating season and year in database to be {} {}".format(
+                raw_show.season, raw_show.year
+            )
+        )
+        db.add_season_year(raw_show.media_id, raw_show.season, raw_show.year)
+
     return len(raw_shows)
 
 
@@ -203,6 +215,14 @@ def _get_shows_info(page, show_ids, ratelimit=60):
         external_links_raw = show["externalLinks"]
         banner_image = show["bannerImage"]
         cover_image = show["coverImage"]["extraLarge"]
+        if not show["season"]:
+            season = "None"
+        else:
+            season = show["season"].capitalize()
+        if not show["seasonYear"]:
+            year = int(show["startDate"]["year"])
+        else:
+            year = int(show["seasonYear"])
 
         external_links = []
 
@@ -272,6 +292,8 @@ def _get_shows_info(page, show_ids, ratelimit=60):
             is_airing=status,
             external_links=external_links,
             images=images,
+            season=season,
+            year=year,
         )
 
         found_shows.append(raw_show)

--- a/src/module_edit_season.py
+++ b/src/module_edit_season.py
@@ -92,7 +92,9 @@ def main(config, db, *args, **kwargs):
 
     info("{} shows found meeting criteria for the season".format(len(found_shows)))
 
-    shows_added = add_update_shows_by_id(db, show_ids=found_shows, ratelimit=ratelimit)
+    shows_added = add_update_shows_by_id(
+        db, enabled=config.discovery_enabled, show_ids=found_shows, ratelimit=ratelimit
+    )
 
     info("{} shows added to the database".format(shows_added))
 

--- a/src/module_wiki.py
+++ b/src/module_wiki.py
@@ -1,0 +1,132 @@
+"""Module to create a series of formatted pages to list episodes in a wiki format"""
+
+import os
+import pathlib
+
+from jinja2 import Template
+from logging import debug, info
+
+from module_episode import _format_post_text
+
+
+def main(config, db, *args, **kwargs):
+    """Main function for the module"""
+
+    seasons = ["winter", "spring", "summer", "fall"]
+    options = ["enable", "disable"]
+
+    # Set a season not to be tracked
+    if len(args) > 0 and args[0].lower() in options:
+        track = args[0] == "enable"
+        if args[1].isnumeric():
+            # A specific show id was given
+            info("Manually setting the tracking status for show id {}".format(args[1]))
+            db.set_tracking(args[1], track=track)
+        elif len(args) == 3 and args[1].lower() in seasons and args[2].isnumeric():
+            # A season was provided
+            info(
+                "Manually setting the tracking status for the {} {} season".format(
+                    args[1], args[2]
+                )
+            )
+            db.set_track_season(args[1], args[2], track=track)
+
+        return
+
+    info("Running the wiki module and outputting formatted files")
+
+    # Build the jinja template
+    debug("Reading template file and creating jinja Template object")
+    with open(config.wiki_template, "r") as file:
+        template = Template(file.read(), trim_blocks=True)
+
+    # First need to get list of season-year pairs that contain episodes
+    debug("Identifying seasons that have episodes for tracked shows")
+    seasons = db.get_seasons_with_episodes()
+
+    # Next, for each season, create the context dict object and output the file
+    info("Identified {} seasons to export as formatted files".format(len(seasons)))
+    for pair in seasons:
+
+        selected_season = pair[0]
+        selected_year = pair[1]
+
+        # Get shows in season from db that have episodes
+        debug(
+            "Fetching tracked shows with episodes from {} {}".format(
+                selected_season, selected_year
+            )
+        )
+        output_shows = db.get_shows_from_season(selected_season, selected_year)
+
+        # Build dict object used for jinja templating
+        context = _build_context(config, db, output_shows)
+        context["season"] = selected_season
+        context["year"] = selected_year
+
+        # Do some filepath stuff
+        debug(
+            "Creating needed filepath for {} {}".format(selected_season, selected_year)
+        )
+        current_dir = os.getcwd()
+        output_folder = os.path.join(
+            current_dir, config.wiki_folder, str(selected_year)
+        )
+        pathlib.Path(output_folder).mkdir(parents=True, exist_ok=True)
+        output_filename = os.path.join(output_folder, selected_season.lower() + ".md")
+
+        # Create the output
+        debug("Writing {}".format(output_filename))
+        rendered = template.render(context=context)
+        with open(output_filename, "w", encoding="utf8") as file:
+            file.write(rendered)
+
+        # Reset the updated column
+        debug(
+            "Marking shows as no longer updated for {} {}".format(
+                selected_season, selected_year
+            )
+        )
+        db.set_season_updated(selected_season, selected_year, updated=False)
+
+    info("Finished writing formatted files")
+
+
+def _build_context(config, db, shows_list):
+    """Build context object for jinja given list of show ids"""
+
+    context = {}
+    context["shows"] = []
+
+    for media_id in shows_list:
+        # Get show
+        debug("Fetching show with id {}".format(media_id))
+        show = db.get_show(media_id)
+
+        # Get an episode to use in _format_post_text
+        debug("Fetching an episode from the show")
+        latest_episode = db.get_latest_episode(show)
+
+        # Check if show has English name
+        if show.name_en:
+            debug("Show has English name")
+            heading_template = config.wiki_show_heading_with_en
+        else:
+            debug("No English name for show")
+            heading_template = config.wiki_show_heading
+
+        # Build heading
+        debug("Formatting section heading")
+        heading = _format_post_text(config, db, latest_episode, heading_template)
+
+        # Build table of episodes
+        debug("Formatting table of episodes")
+        table = _format_post_text(config, db, latest_episode, "{discussions}")
+
+        # Add it to the context object
+        context["shows"].append([heading, table])
+
+    # Sort the list alphabetically by heading
+    context["shows"].sort(key=lambda x: x[0])
+
+    return context

--- a/src/rikka.py
+++ b/src/rikka.py
@@ -9,14 +9,14 @@ from logging import debug, error, exception, info, warning
 from logging.handlers import TimedRotatingFileHandler
 from time import time
 
-# Rikka imports
+# rikka imports
 import config as config_loader
 from data import database
 
 # Metadata
-name = "Rikka"
+name = "rikka"
 description = "episode discussion bot"
-version = "0.7.5"
+version = "0.8.0"
 
 
 def main(config, args, extra_args):
@@ -115,6 +115,12 @@ def main(config, args, extra_args):
 
             m.main(config, db, *extra_args)
 
+        elif config.module == "wiki":
+            debug("Outputting wiki files")
+            import module_wiki as m  # pylint: disable=import-outside-toplevel
+
+            m.main(config, db, *extra_args)
+
     except:
         exception("Unknown exception or error")
         db._db.rollback()
@@ -151,6 +157,7 @@ if __name__ == "__main__":
             "listen",
             "summary",
             "requestable",
+            "wiki",
         ],
         default=["episode"],
         help="runs the specified module",


### PR DESCRIPTION
This PR adds the wiki module. In summary, this module exports all the anime seasons that contain episode discussion threads created by rikka as formatted markdown files. These files can then be used by external scripts as needed/desired. For configuration and usage details, see the updated readme.

Also included in this PR is a minor bugfix I found while testing this that updates the `update_season` module to respect the `discovery_enabled` parameter when adding shows to the database.

## Database Upgrade Instructions

This update requires a database upgrade. To migrate an existing database using the 0.7.X schema, two commands are required. First, you need to create the new `Seasons` table in the database:

```bash
python src/rikka.py -m setup
```

Then, to populate the new table, simply run the `update` module using the `all` argument:

```bash
python src/rikka.py -m update all
```

And you are good to go!

## Config Updates

There is a new section of the config file, `[wiki]`, needed to make use of this module. See the example config for the new parameters.