### PR TITLE
Update config.ini.example

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -7,7 +7,9 @@ community = your_community
 username = your_username
 password = your_password
 # See https://github.com/db0/pythorhead/blob/main/pythorhead/types/language.py for list
-language_id = 37 # 37 = English
+# 37 = English
+language_id = 37 
+
 
 [options]
 # Enable debug logging, default false


### PR DESCRIPTION
Fixed line 10 containing both language_id = 37 and # 37 = English. I moved language_id = 37 to line 11, leaving # 17 = English on line 10.